### PR TITLE
GRBK-1464: '409' error when changing the GB tool to the 'Weighted categories' mode

### DIFF
--- a/server/src/java/org/sakaiproject/gradebook/gwt/sakai/hibernate/GradebookToolServiceImpl.java
+++ b/server/src/java/org/sakaiproject/gradebook/gwt/sakai/hibernate/GradebookToolServiceImpl.java
@@ -1528,7 +1528,7 @@ public class GradebookToolServiceImpl extends HibernateDaoSupport implements Gra
 				setEntity(1, category.getGradebook()).
 				setLong(2, category.getId().longValue()).list());
 				int numNameConflicts = conflictList.size();
-				if(numNameConflicts > 0) {
+				if(!category.isRemoved() && numNameConflicts > 0) {
 					throw new ConflictingCategoryNameException("You cannot save multiple categories in a gradebook with the same name");
 				}
 				if(category.getWeight().doubleValue() > 1 || category.getWeight().doubleValue() < 0)


### PR DESCRIPTION
Steps to reproduce the issue:

0. Switch the GB tool to the "Categories mode".
1. Add a new category with the name "C1". Set the "Drop lowest" field to 1.
2. Remove the category from the last step.
3. Add a new category with the same name that the category from the step 2.
4. Try to change the GB tool to the "Weighted categories mode". An '409' error is shown and no change is done.

